### PR TITLE
Fix null webapp property after reloadParams() when not set at dataimport.properties.

### DIFF
--- a/src/main/java/org/apache/solr/handler/dataimport/scheduler/BaseTimerTask.java
+++ b/src/main/java/org/apache/solr/handler/dataimport/scheduler/BaseTimerTask.java
@@ -30,14 +30,16 @@ public abstract class BaseTimerTask extends TimerTask {
 	protected String reBuildIndexBeginTime;
 	protected String reBuildIndexInterval;
 
+	protected String webAppName;
+
 	protected static final Logger logger = LoggerFactory
 			.getLogger(BaseTimerTask.class);
 
 	public BaseTimerTask(String webAppName, Timer t) throws Exception {
 		// load properties from global dataimport.properties
 		p = new SolrDataImportProperties();
+		this.webAppName = webAppName;
 		reloadParams();
-		fixParams(webAppName);
 
 		if (!syncEnabled.equals("1"))
 			throw new Exception("Schedule disabled");
@@ -71,6 +73,7 @@ public abstract class BaseTimerTask extends TimerTask {
 		reBuildIndexInterval = p
 				.getProperty(SolrDataImportProperties.REBUILDINDEXINTERVAL);
 
+		fixParams(this.webAppName);
 	}
 
 	protected void fixParams(String webAppName) {


### PR DESCRIPTION
Sometimes BaseTimerTask.reloadParams() is called leaving the property `webapp` null if it isn't set at `dataimport.properties`, which leads to this:

`org.apache.solr.handler.dataimport.scheduler.DeltaImportHTTPPostScheduler run
SEVERE: Failed to prepare for sendHttpPost
java.lang.NullPointerException
        at org.apache.solr.handler.dataimport.scheduler.DeltaImportHTTPPostScheduler.run(DeltaImportHTTPPostScheduler.java:27)
        at java.util.TimerThread.mainLoop(Timer.java:567)
        at java.util.TimerThread.run(Timer.java:517)`